### PR TITLE
update Dockerfile to Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.12-alpine
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY /src/exporter.py .


### PR DESCRIPTION
To fix a CVE in the docker image, update to the latest Python

docker image: philipp533/goodwe-prometheus-exporter:1.45-python3.12